### PR TITLE
goTo() method updated

### DIFF
--- a/src/js/jquery.slideform.js
+++ b/src/js/jquery.slideform.js
@@ -236,6 +236,9 @@
 
             // Let's set the new max if available.
             $max = ( slide > $max ) ? slide : $max;
+            
+            // Update the $current variable so that it won't go back to a previou8s step
+            $current = slide;
 
             // Let's update buttons status
             updateButtonsStatus( slide );


### PR DESCRIPTION
Updated the $current variable so that it won't go back to skipped step. The current behavior takes the slide back to where it was even if some slides are skipped using goTo ()method.